### PR TITLE
Регистронезависимый белый список

### DIFF
--- a/libLauncher/src/main/java/ru/gravit/launcher/profiles/ClientProfile.java
+++ b/libLauncher/src/main/java/ru/gravit/launcher/profiles/ClientProfile.java
@@ -279,7 +279,7 @@ ClientProfile extends ConfigObject implements Comparable<ClientProfile> {
     @LauncherAPI
     public boolean isWhitelistContains(String username) {
         if (!useWhitelist.getValue()) return true;
-        return whitelist.stream(StringConfigEntry.class).anyMatch(e -> e.equals(username));
+        return whitelist.stream(StringConfigEntry.class).anyMatch(e -> e.equalsIgnoreCase(username));
     }
 
     @LauncherAPI


### PR DESCRIPTION
На разных этапах регистр username может отличаться.
Пример:
Ник в бд: Test
Ник в whitelist профиля: test

В этом случае, игрок пройдет AuthResponse и SetprofileResponse, но на UpdateResponse получит ошибку.