### PR TITLE
[FIX] Правка логики работы дерева опциональных модов

### DIFF
--- a/Launcher/runtime/dialog/dialog.js
+++ b/Launcher/runtime/dialog/dialog.js
@@ -198,9 +198,9 @@ function verifyLauncher(e) {
         }
         overlay.swap(0, processing.overlay, function(event) makeProfilesRequest(function(result) {
             settings.lastProfiles = result.profiles;
-            options.load();
             // Update profiles list and hide overlay
             updateProfilesList(result.profiles);
+            options.load();
             overlay.hide(0, function() {
                   if (cliParams.autoLogin) {
                       goAuth(null);


### PR DESCRIPTION
При перезаходе в лаунчер и отключении основной опциональной модификации (от которой зависят другие) - эти же другие не отключались, что приводило к различным конфликтам.