### PR TITLE
Fix runtime exception during refresh oauth access token

### DIFF
--- a/LaunchServer/src/main/java/pro/gravit/launchserver/auth/core/HttpAuthCoreProvider.java
+++ b/LaunchServer/src/main/java/pro/gravit/launchserver/auth/core/HttpAuthCoreProvider.java
@@ -113,7 +113,7 @@ public class HttpAuthCoreProvider extends AuthCoreProvider {
         }
         try {
             return requester.send(requester.post(refreshTokenUrl, new RefreshTokenRequest(refreshToken, context),
-                    null), AuthManager.AuthReport.class).getOrThrow();
+                    null), HttpAuthReport.class).getOrThrow().toAuthReport();
         } catch (IOException e) {
             logger.error(e);
             return null;


### PR DESCRIPTION
Fixed runtime exception during refresh oauth access token

Stacktrace below:

java.lang.RuntimeException: Unable to create instance of interface pro.gravit.launchserver.auth.core.UserSession. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem.
        at com.google.gson.internal.ConstructorConstructor$16.construct(ConstructorConstructor.java:275) ~[LaunchServer.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:211) ~[LaunchServer.jar:?]
        at marcono1234.gson.recordadapter.RecordTypeAdapterFactory$1.read(RecordTypeAdapterFactory.java:600) ~[gson-record-type-adapter-factory-v0.2.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:991) ~[LaunchServer.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:1062) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.HttpRequester$SimpleErrorHandler.applyJson(HttpRequester.java:35) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.helper.HttpHelper$HttpJsonErrorHandler.apply(HttpHelper.java:71) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.helper.HttpHelper.send(HttpHelper.java:94) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.HttpRequester.send(HttpRequester.java:78) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.auth.core.HttpAuthCoreProvider.refreshAccessToken(HttpAuthCoreProvider.java:127) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.socket.response.auth.RefreshTokenResponse.execute(RefreshTokenResponse.java:40) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.socket.WebSocketService.process(WebSocketService.java:163) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.socket.WebSocketService.process(WebSocketService.java:114) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.socket.handlers.WebSocketFrameHandler.channelRead0(WebSocketFrameHandler.java:71) ~[LaunchServer.jar:?]
        at pro.gravit.launchserver.socket.handlers.WebSocketFrameHandler.channelRead0(WebSocketFrameHandler.java:20) ~[LaunchServer.jar:?]
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:102) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:102) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[netty-codec-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89) ~[netty-codec-http-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327) ~[netty-codec-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299) ~[netty-codec-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496) ~[netty-transport-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.78.Final.jar:4.1.78.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.78.Final.jar:4.1.78.Final]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.UnsupportedOperationException: Interface can't be instantiated! Interface name: pro.gravit.launchserver.auth.core.UserSession
        at com.google.gson.internal.UnsafeAllocator.assertInstantiable(UnsafeAllocator.java:118) ~[LaunchServer.jar:?]
        at com.google.gson.internal.UnsafeAllocator$1.newInstance(UnsafeAllocator.java:49) ~[LaunchServer.jar:?]
        at com.google.gson.internal.ConstructorConstructor$16.construct(ConstructorConstructor.java:272) ~[LaunchServer.jar:?]
        ... 53 more