### PR TITLE
Фикс зависимостей и возможность взаимоисключения для опциональных модов

### DIFF
--- a/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/ClientProfile.java
+++ b/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/ClientProfile.java
@@ -254,6 +254,12 @@ public final class ClientProfile implements Comparable<ClientProfile> {
                     file.conflict[i] = getOptionalFile(file.conflictFile[i].name);
                 }
             }
+            if(file.xorConflictFile != null) {
+                file.xorConflict = new OptionalFile[file.xorConflictFile.length];
+                for(int i = 0; i < file.xorConflictFile.length; ++i) {
+                    file.xorConflict[i] = getOptionalFile(file.xorConflictFile[i].name);
+                }
+            }
         }
     }
 
@@ -368,6 +374,10 @@ public final class ClientProfile implements Comparable<ClientProfile> {
             if (f.dependenciesFile != null) for (OptionalDepend s : f.dependenciesFile) {
                 if (s == null)
                     throw new IllegalArgumentException(String.format("Found null entry in updateOptional.%s.dependenciesFile", f.name));
+            }
+            if(f.xorConflictFile != null) for (OptionalDepend s : f.xorConflictFile) {
+                if (s == null)
+                    throw new IllegalArgumentException(String.format("Found null entry in updateOptional.%s.xorConflictFile", f.name));
             }
             if (f.triggersList != null) {
                 for (OptionalTrigger trigger : f.triggersList) {

--- a/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/ClientProfile.java
+++ b/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/ClientProfile.java
@@ -375,9 +375,10 @@ public final class ClientProfile implements Comparable<ClientProfile> {
                 if (s == null)
                     throw new IllegalArgumentException(String.format("Found null entry in updateOptional.%s.dependenciesFile", f.name));
             }
-            if(f.xorConflictFile != null) for (OptionalDepend s : f.xorConflictFile) {
-                if (s == null)
-                    throw new IllegalArgumentException(String.format("Found null entry in updateOptional.%s.xorConflictFile", f.name));
+            if(f.xorConflictFile != null)
+                for (OptionalDepend s : f.xorConflictFile) {
+                    if (s == null)
+                        throw new IllegalArgumentException(String.format("Found null entry in updateOptional.%s.xorConflictFile", f.name));
             }
             if (f.triggersList != null) {
                 for (OptionalTrigger trigger : f.triggersList) {

--- a/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/optional/OptionalFile.java
+++ b/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/optional/OptionalFile.java
@@ -24,9 +24,13 @@ public class OptionalFile {
     @LauncherNetworkAPI
     public OptionalDepend[] conflictFile;
     @LauncherNetworkAPI
+    public OptionalDepend[] xorConflictFile;
+    @LauncherNetworkAPI
     public transient OptionalFile[] dependencies;
     @LauncherNetworkAPI
     public transient OptionalFile[] conflict;
+    @LauncherNetworkAPI
+    public transient OptionalFile[] xorConflict;
     @LauncherNetworkAPI
     public int subTreeLevel = 1;
     @LauncherNetworkAPI

--- a/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/optional/OptionalView.java
+++ b/LauncherAPI/src/main/java/pro/gravit/launcher/profiles/optional/OptionalView.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Arrays;
 import java.util.function.BiConsumer;
 
 public class OptionalView {
@@ -111,6 +112,11 @@ public class OptionalView {
                 disable(conflict, callback);
             }
         }
+        if(file.xorConflict != null) {
+            for(OptionalFile xorConflict : file.xorConflict) {
+                disable(xorConflict, callback);
+            }
+        }
     }
 
     public void disable(OptionalFile file, BiConsumer<OptionalFile, Boolean> callback) {
@@ -127,6 +133,11 @@ public class OptionalView {
                 if (installInfo != null && !installInfo.isManual) {
                     disable(file, callback);
                 }
+            }
+        }
+        if (file.xorConflict != null) {
+            if (Arrays.stream(file.xorConflict).noneMatch(this::isEnabled)) {
+                enable(file.xorConflict[0], false, callback);
             }
         }
     }


### PR DESCRIPTION
**Feature:** Позволяет сделать моды конфликтующими по принципу XOR. Пример использования: создание профиля клиента с возможностью выбора строго одного из двух(или более) взаимоисключающих модов.


Юзкейс: 

Есть два набора модов:
1. Optifine
2. Soidum и некоторые альтернативы фич optifine(CIT)

Optifabric работает менее стабильно, чем Sodium и альтернативы, однако, запускается на большем количестве устройств за счет более мягких требований к OpenGL(требуется OpenGL 3.2), в то время как Sodium(как и альтернативы CIT) работает шустрее, но требует OpenGL 4.3, соответственно запускается на меньшем количестве компьютеров.

Как итог, есть необходимость заставить игрока установить 1 из 2 модов, чтобы обеспечить поддержку CIT


Пример конфига:
```json
"updateOptional": [
	{
	  "actions": [
        {
          "files": {
            "mods/optifine.jar": "",
	    "mods/optifabric.jar": ""
          },
          "type": "file"
        }
      ],
      "name": "Optifine",
      "info": "Оптимизационный мод для старых ПК",
      "visible": true,
      "xorConflictFile": [{"name":"Sodium"}],
      "mark": false,
      "limited": false
	},
	{
	  "actions": [
        {
          "files": {
            "mods/sodium.jar": ""
          },
          "type": "file"
        }
      ],
      "name": "Sodium",
      "info": "Оптимизационный мод для новых ПК",
      "xorConflictFile": [{"name":"Optifine"}],
      "visible": true,
      "mark": true,
      "limited": false
     }
]
```

**Fix:** Исправляет возможный краш клиента, если добавить мод в опциональные, но забыть про его зависимости и закидывать их уже задним числом. (Также фиксит требование XOR на активацию хотя бы одного мода).
