### PR TITLE
[FIX] Fix log4j config

### DIFF
--- a/LaunchServer/src/main/java/pro/gravit/launchserver/Main.java
+++ b/LaunchServer/src/main/java/pro/gravit/launchserver/Main.java
@@ -37,7 +37,7 @@ public class Main {
             Path log4jConfigPath = Path.of("log4j2.xml");
             if(!Files.exists(log4jConfigPath)) {
                 try(FileOutputStream output = new FileOutputStream(log4jConfigPath.toFile())) {
-                    try(InputStream input = Main.class.getResourceAsStream("log4j2.xml")) {
+                    try(InputStream input = Main.class.getResourceAsStream("/log4j2.xml")) {
                         if(input == null) {
                             return;
                         }


### PR DESCRIPTION
Right now launchserver starts with empty log4j config due to spelling mistake in resource path.