### PR TITLE
Fix connection pool exhaustion, statement leaks, and texture API error handling

### DIFF
--- a/components/launchserver/src/main/java/pro/gravit/launchserver/HttpRequester.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/HttpRequester.java
@@ -78,7 +78,16 @@ public class HttpRequester {
         @Override
         public HttpHelper.HttpOptional<T, SimpleError> applyJson(JsonElement response, int statusCode) {
             if (statusCode < 200 || statusCode >= 300) {
-                return new HttpHelper.HttpOptional<>(null, Launcher.gsonManager.gson.fromJson(response, SimpleError.class), statusCode);
+                SimpleError error = null;
+                try {
+                    error = Launcher.gsonManager.gson.fromJson(response, SimpleError.class);
+                } catch (Exception ignored) {
+                }
+                if (error == null || (error.error == null && error.code == 0)) {
+                    error = new SimpleError("HTTP " + statusCode);
+                    error.code = statusCode;
+                }
+                return new HttpHelper.HttpOptional<>(null, error, statusCode);
             }
             if (type == Void.class) {
                 return new HttpHelper.HttpOptional<>(null, null, statusCode);

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/HttpRequester.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/HttpRequester.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 public class HttpRequester {
     private transient final HttpClient httpClient = HttpClient.newBuilder().build();
@@ -65,6 +66,10 @@ public class HttpRequester {
 
     public <T> HttpHelper.HttpOptional<T, SimpleError> send(HttpRequest request, Type type) throws IOException {
         return HttpHelper.send(httpClient, request, makeEH(type));
+    }
+
+    public <T> CompletableFuture<HttpHelper.HttpOptional<T, SimpleError>> sendAsync(HttpRequest request, Type type) {
+        return HttpHelper.sendAsync(httpClient, request, makeEH(type));
     }
 
 

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/MySQLSourceConfig.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/MySQLSourceConfig.java
@@ -39,7 +39,7 @@ public final class MySQLSourceConfig implements AutoCloseable, SQLSourceConfig {
     private boolean useHikari;
 
     // Cache
-    private transient DataSource source;
+    private transient volatile DataSource source;
     private transient boolean hikari;
 
 
@@ -69,59 +69,64 @@ public final class MySQLSourceConfig implements AutoCloseable, SQLSourceConfig {
     }
 
 
-    public synchronized Connection getConnection() throws SQLException {
-        if (source == null) { // New data source
-            MysqlDataSource mysqlSource = new MysqlDataSource();
-            mysqlSource.setCharacterEncoding("UTF-8");
-
-            // Prep statements cache
-            mysqlSource.setPrepStmtCacheSize(250);
-            mysqlSource.setPrepStmtCacheSqlLimit(2048);
-            mysqlSource.setCachePrepStmts(true);
-            mysqlSource.setUseServerPrepStmts(true);
-
-            // General optimizations
-            mysqlSource.setCacheServerConfiguration(true);
-            mysqlSource.setUseLocalSessionState(true);
-            mysqlSource.setRewriteBatchedStatements(true);
-            mysqlSource.setMaintainTimeStats(false);
-            mysqlSource.setUseUnbufferedInput(false);
-            mysqlSource.setUseReadAheadInput(false);
-            mysqlSource.setUseSSL(useSSL);
-            mysqlSource.setVerifyServerCertificate(verifyCertificates);
-            // Set credentials
-            mysqlSource.setServerName(address);
-            mysqlSource.setPortNumber(port);
-            mysqlSource.setUser(username);
-            mysqlSource.setPassword(password);
-            mysqlSource.setDatabaseName(database);
-            mysqlSource.setTcpNoDelay(true);
-            if (timezone != null) mysqlSource.setServerTimezone(timezone);
-            hikari = false;
-            // Try using HikariCP
-            source = mysqlSource;
-            if (useHikari) {
-                try {
-                    Class.forName("com.zaxxer.hikari.HikariDataSource");
-                    hikari = true; // Used for shutdown. Not instanceof because of possible classpath error
-                    HikariConfig hikariConfig = new HikariConfig();
-                    hikariConfig.setDataSource(mysqlSource);
-                    hikariConfig.setPoolName(poolName);
-                    hikariConfig.setMinimumIdle(1);
-                    hikariConfig.setMaximumPoolSize(MAX_POOL_SIZE);
-                    hikariConfig.setConnectionTestQuery("SELECT 1");
-                    hikariConfig.setConnectionTimeout(1000);
-                    hikariConfig.setLeakDetectionThreshold(2000);
-                    hikariConfig.setMaxLifetime(hikariMaxLifetime);
-                    // Set HikariCP pool
-                    // Replace source with hds
-                    source = new HikariDataSource(hikariConfig);
-                } catch (ClassNotFoundException ignored) {
-                    logger.debug("HikariCP isn't in classpath for '{}'", poolName);
+    public Connection getConnection() throws SQLException {
+        DataSource ds = source;
+        if (ds == null) {
+            synchronized (this) {
+                ds = source;
+                if (ds == null) {
+                    ds = initDataSource();
+                    source = ds;
                 }
             }
-
         }
-        return source.getConnection();
+        return ds.getConnection();
+    }
+
+    private DataSource initDataSource() throws SQLException {
+        MysqlDataSource mysqlSource = new MysqlDataSource();
+        mysqlSource.setCharacterEncoding("UTF-8");
+
+        mysqlSource.setPrepStmtCacheSize(250);
+        mysqlSource.setPrepStmtCacheSqlLimit(2048);
+        mysqlSource.setCachePrepStmts(true);
+        mysqlSource.setUseServerPrepStmts(true);
+
+        mysqlSource.setCacheServerConfiguration(true);
+        mysqlSource.setUseLocalSessionState(true);
+        mysqlSource.setRewriteBatchedStatements(true);
+        mysqlSource.setMaintainTimeStats(false);
+        mysqlSource.setUseUnbufferedInput(false);
+        mysqlSource.setUseReadAheadInput(false);
+        mysqlSource.setUseSSL(useSSL);
+        mysqlSource.setVerifyServerCertificate(verifyCertificates);
+        mysqlSource.setServerName(address);
+        mysqlSource.setPortNumber(port);
+        mysqlSource.setUser(username);
+        mysqlSource.setPassword(password);
+        mysqlSource.setDatabaseName(database);
+        mysqlSource.setTcpNoDelay(true);
+        if (timezone != null) mysqlSource.setServerTimezone(timezone);
+        hikari = false;
+        DataSource result = mysqlSource;
+        if (useHikari) {
+            try {
+                Class.forName("com.zaxxer.hikari.HikariDataSource");
+                hikari = true;
+                HikariConfig hikariConfig = new HikariConfig();
+                hikariConfig.setDataSource(mysqlSource);
+                hikariConfig.setPoolName(poolName);
+                hikariConfig.setMinimumIdle(1);
+                hikariConfig.setMaximumPoolSize(MAX_POOL_SIZE);
+                hikariConfig.setConnectionTestQuery("SELECT 1");
+                hikariConfig.setConnectionTimeout(1000);
+                hikariConfig.setLeakDetectionThreshold(2000);
+                hikariConfig.setMaxLifetime(hikariMaxLifetime);
+                result = new HikariDataSource(hikariConfig);
+            } catch (ClassNotFoundException ignored) {
+                logger.debug("HikariCP isn't in classpath for '{}'", poolName);
+            }
+        }
+        return result;
     }
 }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/PostgreSQLSourceConfig.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/PostgreSQLSourceConfig.java
@@ -33,7 +33,7 @@ public final class PostgreSQLSourceConfig implements AutoCloseable, SQLSourceCon
     private final long hikariMaxLifetime = MINUTES.toMillis(30); // 30 minutes
 
     // Cache
-    private transient DataSource source;
+    private transient volatile DataSource source;
     private transient boolean hikari;
 
     @Override
@@ -43,43 +43,48 @@ public final class PostgreSQLSourceConfig implements AutoCloseable, SQLSourceCon
         }
     }
 
-    public synchronized Connection getConnection() throws SQLException {
-        if (source == null) { // New data source
-            PGSimpleDataSource postgresqlSource = new PGSimpleDataSource();
-
-            // Set credentials
-            postgresqlSource.setServerNames(addresses);
-            postgresqlSource.setPortNumbers(ports);
-            postgresqlSource.setUser(username);
-            postgresqlSource.setPassword(password);
-            postgresqlSource.setDatabaseName(database);
-
-            // Try using HikariCP
-            source = postgresqlSource;
-
-            //noinspection Duplicates
-            try {
-                Class.forName("com.zaxxer.hikari.HikariDataSource");
-                hikari = true; // Used for shutdown. Not instanceof because of possible classpath error
-
-                // Set HikariCP pool
-                HikariDataSource hikariSource = new HikariDataSource();
-                hikariSource.setDataSource(source);
-
-                // Set pool settings
-                hikariSource.setPoolName(poolName);
-                hikariSource.setMinimumIdle(0);
-                hikariSource.setMaximumPoolSize(MAX_POOL_SIZE);
-                hikariSource.setIdleTimeout(SECONDS.toMillis(TIMEOUT));
-                hikariSource.setMaxLifetime(hikariMaxLifetime);
-
-                // Replace source with hds
-                source = hikariSource;
-                logger.info("HikariCP pooling enabled for '{}'", poolName);
-            } catch (ClassNotFoundException ignored) {
-                logger.warn("HikariCP isn't in classpath for '{}'", poolName);
+    public Connection getConnection() throws SQLException {
+        DataSource ds = source;
+        if (ds == null) {
+            synchronized (this) {
+                ds = source;
+                if (ds == null) {
+                    ds = initDataSource();
+                    source = ds;
+                }
             }
         }
-        return source.getConnection();
+        return ds.getConnection();
+    }
+
+    private DataSource initDataSource() {
+        PGSimpleDataSource postgresqlSource = new PGSimpleDataSource();
+
+        postgresqlSource.setServerNames(addresses);
+        postgresqlSource.setPortNumbers(ports);
+        postgresqlSource.setUser(username);
+        postgresqlSource.setPassword(password);
+        postgresqlSource.setDatabaseName(database);
+
+        hikari = false;
+        DataSource result = postgresqlSource;
+        try {
+            Class.forName("com.zaxxer.hikari.HikariDataSource");
+            hikari = true;
+
+            HikariDataSource hikariSource = new HikariDataSource();
+            hikariSource.setDataSource(postgresqlSource);
+            hikariSource.setPoolName(poolName);
+            hikariSource.setMinimumIdle(0);
+            hikariSource.setMaximumPoolSize(MAX_POOL_SIZE);
+            hikariSource.setIdleTimeout(SECONDS.toMillis(TIMEOUT));
+            hikariSource.setMaxLifetime(hikariMaxLifetime);
+
+            result = hikariSource;
+            logger.info("HikariCP pooling enabled for '{}'", poolName);
+        } catch (ClassNotFoundException ignored) {
+            logger.warn("HikariCP isn't in classpath for '{}'", poolName);
+        }
+        return result;
     }
 }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/core/AbstractSQLCoreProvider.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/core/AbstractSQLCoreProvider.java
@@ -504,7 +504,7 @@ public abstract class AbstractSQLCoreProvider extends AuthCoreProvider implement
             try (ResultSet rs = s.executeQuery()) {
                 SQLUser user = constructUser(rs);
                 if (user != null) {
-                    user.permissions = loadPermissions(user.uuid.toString());
+                    user.permissions = loadPermissions(c, user.uuid.toString());
                 }
                 return user;
             }
@@ -557,18 +557,23 @@ public abstract class AbstractSQLCoreProvider extends AuthCoreProvider implement
     }
 
     public ClientPermissions loadPermissions(String uuid) throws SQLException {
+        try (Connection c = getSQLConfig().getConnection()) {
+            return loadPermissions(c, uuid);
+        }
+    }
+
+    public ClientPermissions loadPermissions(Connection c, String uuid) throws SQLException {
         List<String> roles = isRolesEnabled()
-                ? queryStringColumn(queryRolesByUserUUID, uuid, rolesNameColumn)
+                ? queryStringColumn(c, queryRolesByUserUUID, uuid, rolesNameColumn)
                 : List.of();
         List<String> perms = isPermissionsEnabled()
-                ? queryStringColumn(queryPermissionsByUUIDSQL, uuid, permissionsPermissionColumn)
+                ? queryStringColumn(c, queryPermissionsByUUIDSQL, uuid, permissionsPermissionColumn)
                 : List.of();
         return new ClientPermissions(roles, perms);
     }
 
-    private List<String> queryStringColumn(String sql, String param, String column) throws SQLException {
-        try (Connection c = getSQLConfig().getConnection();
-             PreparedStatement s = c.prepareStatement(sql)) {
+    private List<String> queryStringColumn(Connection c, String sql, String param, String column) throws SQLException {
+        try (PreparedStatement s = c.prepareStatement(sql)) {
             s.setString(1, param);
             s.setQueryTimeout(MySQLSourceConfig.TIMEOUT);
             try (ResultSet rs = s.executeQuery()) {

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/core/MySQLCoreProvider.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/core/MySQLCoreProvider.java
@@ -27,6 +27,7 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     public double criticalCompareLevel = 1.0;
     private transient String sqlFindHardwareByPublicKey;
     private transient String sqlFindHardwareByData;
+    private transient String sqlFindHardwareByDataFiltered;
     private transient String sqlFindHardwareById;
     private transient String sqlCreateHardware;
     private transient String sqlCreateHWIDLog;
@@ -54,6 +55,7 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
             sqlUsersByHwidId = "SELECT %s FROM %s WHERE `%s` = ?".formatted(userInfoCols, table, hardwareIdColumn);
         if (sqlFindHardwareByData == null)
             sqlFindHardwareByData = "SELECT %s FROM %s".formatted(hardwareInfoCols, tableHWID);
+        sqlFindHardwareByDataFiltered = "SELECT %s FROM %s WHERE `hwDiskId` = ? OR `baseboardSerialNumber` = ?".formatted(hardwareInfoCols, tableHWID);
         if (sqlCreateHardware == null)
             sqlCreateHardware = "INSERT INTO `%s` (`publickey`, `hwDiskId`, `baseboardSerialNumber`, `displayId`, `bitness`, `totalMemory`, `logicalProcessors`, `physicalProcessors`, `processorMaxFreq`, `graphicCard`, `battery`, `banned`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '0')".formatted(tableHWID);
         if (sqlCreateHWIDLog == null)
@@ -95,16 +97,17 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     }
 
     private void setUserHardwareId(Connection connection, UUID uuid, long hwidId) throws SQLException {
-        PreparedStatement s = connection.prepareStatement(sqlUpdateUsers);
-        s.setLong(1, hwidId);
-        s.setString(2, uuid.toString());
-        s.executeUpdate();
+        try (PreparedStatement s = connection.prepareStatement(sqlUpdateUsers)) {
+            s.setLong(1, hwidId);
+            s.setString(2, uuid.toString());
+            s.executeUpdate();
+        }
     }
 
     @Override
     public UserHardware getHardwareInfoByPublicKey(byte[] publicKey) {
-        try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlFindHardwareByPublicKey);
+        try (Connection connection = mySQLHolder.getConnection();
+             PreparedStatement s = connection.prepareStatement(sqlFindHardwareByPublicKey)) {
             s.setBlob(1, new ByteArrayInputStream(publicKey));
             try (ResultSet set = s.executeQuery()) {
                 if (set.next()) {
@@ -122,26 +125,48 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     @Override
     public UserHardware getHardwareInfoByData(HardwareReportRequest.HardwareInfo info) {
         try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlFindHardwareByData);
-            try (ResultSet set = s.executeQuery()) {
-                while (set.next()) {
-                    MySQLUserHardware hw = fetchHardwareInfo(set);
-                    HardwareInfoCompareResult result = compareHardwareInfo(hw.getHardwareInfo(), info);
-                    if (result.compareLevel > criticalCompareLevel) {
-                        return hw;
-                    }
-                }
-            }
+            MySQLUserHardware result = findHardwareByDataFiltered(connection, info);
+            if (result != null) return result;
+            return findHardwareByDataFullScan(connection, info);
         } catch (SQLException | IOException throwables) {
             logger.error("SQL Error", throwables);
         }
         return null;
     }
 
+    private MySQLUserHardware findHardwareByDataFiltered(Connection connection, HardwareReportRequest.HardwareInfo info) throws SQLException, IOException {
+        try (PreparedStatement s = connection.prepareStatement(sqlFindHardwareByDataFiltered)) {
+            s.setString(1, info.hwDiskId);
+            s.setString(2, info.baseboardSerialNumber);
+            try (ResultSet set = s.executeQuery()) {
+                while (set.next()) {
+                    MySQLUserHardware hw = fetchHardwareInfo(set);
+                    if (compareHardwareInfo(hw.getHardwareInfo(), info).compareLevel > criticalCompareLevel) {
+                        return hw;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private MySQLUserHardware findHardwareByDataFullScan(Connection connection, HardwareReportRequest.HardwareInfo info) throws SQLException, IOException {
+        try (PreparedStatement s = connection.prepareStatement(sqlFindHardwareByData);
+             ResultSet set = s.executeQuery()) {
+            while (set.next()) {
+                MySQLUserHardware hw = fetchHardwareInfo(set);
+                if (compareHardwareInfo(hw.getHardwareInfo(), info).compareLevel > criticalCompareLevel) {
+                    return hw;
+                }
+            }
+        }
+        return null;
+    }
+
     @Override
     public UserHardware getHardwareInfoById(String id) {
-        try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlFindHardwareById);
+        try (Connection connection = mySQLHolder.getConnection();
+             PreparedStatement s = connection.prepareStatement(sqlFindHardwareById)) {
             s.setLong(1, Long.parseLong(id));
             try (ResultSet set = s.executeQuery()) {
                 if (set.next()) {
@@ -158,8 +183,8 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
 
     @Override
     public UserHardware createHardwareInfo(HardwareReportRequest.HardwareInfo hardwareInfo, byte[] publicKey) {
-        try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlCreateHardware, Statement.RETURN_GENERATED_KEYS);
+        try (Connection connection = mySQLHolder.getConnection();
+             PreparedStatement s = connection.prepareStatement(sqlCreateHardware, Statement.RETURN_GENERATED_KEYS)) {
             s.setBlob(1, new ByteArrayInputStream(publicKey));
             s.setString(2, hardwareInfo.hwDiskId);
             s.setString(3, hardwareInfo.baseboardSerialNumber);
@@ -174,7 +199,6 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
             s.executeUpdate();
             try (ResultSet generatedKeys = s.getGeneratedKeys()) {
                 if (generatedKeys.next()) {
-                    //writeHwidLog(connection, generatedKeys.getLong(1), publicKey);
                     long id = generatedKeys.getLong(1);
                     return new MySQLUserHardware(hardwareInfo, publicKey, id, false);
                 }
@@ -204,8 +228,8 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     public void addPublicKeyToHardwareInfo(UserHardware hardware, byte[] publicKey) {
         MySQLUserHardware mySQLUserHardware = (MySQLUserHardware) hardware;
         mySQLUserHardware.publicKey = publicKey;
-        try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlUpdateHardwarePublicKey);
+        try (Connection connection = mySQLHolder.getConnection();
+             PreparedStatement s = connection.prepareStatement(sqlUpdateHardwarePublicKey)) {
             s.setBlob(1, new ByteArrayInputStream(publicKey));
             s.setLong(2, mySQLUserHardware.id);
             s.executeUpdate();
@@ -217,12 +241,12 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     @Override
     public Iterable<User> getUsersByHardwareInfo(UserHardware hardware) {
         List<User> users = new LinkedList<>();
-        try (Connection c = mySQLHolder.getConnection()) {
-            PreparedStatement s = c.prepareStatement(sqlUsersByHwidId);
+        try (Connection c = mySQLHolder.getConnection();
+             PreparedStatement s = c.prepareStatement(sqlUsersByHwidId)) {
             s.setLong(1, Long.parseLong(hardware.getId()));
             s.setQueryTimeout(MySQLSourceConfig.TIMEOUT);
             try (ResultSet set = s.executeQuery()) {
-                while (!set.isLast()) {
+                while (set.next()) {
                     users.add(constructUser(set));
                 }
             }
@@ -237,8 +261,8 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     public void banHardware(UserHardware hardware) {
         MySQLUserHardware mySQLUserHardware = (MySQLUserHardware) hardware;
         mySQLUserHardware.banned = true;
-        try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlUpdateHardwareBanned);
+        try (Connection connection = mySQLHolder.getConnection();
+             PreparedStatement s = connection.prepareStatement(sqlUpdateHardwareBanned)) {
             s.setBoolean(1, true);
             s.setLong(2, mySQLUserHardware.id);
             s.executeUpdate();
@@ -251,8 +275,8 @@ public class MySQLCoreProvider extends AbstractSQLCoreProvider implements AuthSu
     public void unbanHardware(UserHardware hardware) {
         MySQLUserHardware mySQLUserHardware = (MySQLUserHardware) hardware;
         mySQLUserHardware.banned = false;
-        try (Connection connection = mySQLHolder.getConnection()) {
-            PreparedStatement s = connection.prepareStatement(sqlUpdateHardwareBanned);
+        try (Connection connection = mySQLHolder.getConnection();
+             PreparedStatement s = connection.prepareStatement(sqlUpdateHardwareBanned)) {
             s.setBoolean(1, false);
             s.setLong(2, mySQLUserHardware.id);
             s.executeUpdate();

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/core/SQLCoreProvider.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/core/SQLCoreProvider.java
@@ -80,6 +80,7 @@ public class SQLCoreProvider extends AbstractSQLCoreProvider
 
     private transient String sqlFindHardwareByPublicKey;
     private transient String sqlFindHardwareByData;
+    private transient String sqlFindHardwareByDataFiltered;
     private transient String sqlFindHardwareById;
     private transient String sqlCreateHardware;
     private transient String sqlCreateHWIDLog;
@@ -132,6 +133,9 @@ public class SQLCoreProvider extends AbstractSQLCoreProvider
 
         sqlFindHardwareByData = resolve(customFindHardwareByData,
                 "SELECT %s FROM %s".formatted(hwCols, tableHWID));
+
+        sqlFindHardwareByDataFiltered =
+                "SELECT %s FROM %s WHERE hwDiskId = ? OR baseboardSerialNumber = ?".formatted(hwCols, tableHWID);
 
         sqlCreateHardware = resolve(customCreateHardware,
                 ("INSERT INTO %s " +
@@ -203,8 +207,34 @@ public class SQLCoreProvider extends AbstractSQLCoreProvider
 
     @Override
     public UserHardware getHardwareInfoByData(HardwareReportRequest.HardwareInfo info) {
-        try (Connection c = holder.getConnection();
-             PreparedStatement s = c.prepareStatement(sqlFindHardwareByData);
+        try (Connection c = holder.getConnection()) {
+            SQLUserHardware result = findHardwareByDataFiltered(c, info);
+            if (result != null) return result;
+            return findHardwareByDataFullScan(c, info);
+        } catch (SQLException e) {
+            logger.error("SQL error in getHardwareInfoByData", e);
+        }
+        return null;
+    }
+
+    private SQLUserHardware findHardwareByDataFiltered(Connection c, HardwareReportRequest.HardwareInfo info) throws SQLException {
+        try (PreparedStatement s = c.prepareStatement(sqlFindHardwareByDataFiltered)) {
+            s.setString(1, info.hwDiskId);
+            s.setString(2, info.baseboardSerialNumber);
+            try (ResultSet rs = s.executeQuery()) {
+                while (rs.next()) {
+                    SQLUserHardware hw = mapHardware(rs);
+                    if (compareHardwareInfo(hw.getHardwareInfo(), info).compareLevel >= criticalCompareLevel) {
+                        return hw;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private SQLUserHardware findHardwareByDataFullScan(Connection c, HardwareReportRequest.HardwareInfo info) throws SQLException {
+        try (PreparedStatement s = c.prepareStatement(sqlFindHardwareByData);
              ResultSet rs = s.executeQuery()) {
             while (rs.next()) {
                 SQLUserHardware hw = mapHardware(rs);
@@ -212,8 +242,6 @@ public class SQLCoreProvider extends AbstractSQLCoreProvider
                     return hw;
                 }
             }
-        } catch (SQLException e) {
-            logger.error("SQL error in getHardwareInfoByData", e);
         }
         return null;
     }
@@ -305,7 +333,7 @@ public class SQLCoreProvider extends AbstractSQLCoreProvider
             try (ResultSet rs = s.executeQuery()) {
                 while (rs.next()) {
                     SQLUser user = constructUserFromRow(rs);
-                    user.permissions = loadPermissions(user.uuid.toString());
+                    user.permissions = loadPermissions(c, user.uuid.toString());
                     users.add(user);
                 }
             }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/texture/JsonTextureProvider.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/texture/JsonTextureProvider.java
@@ -40,13 +40,31 @@ public class JsonTextureProvider extends TextureProvider {
 
     @Override
     public Map<String, Texture> getAssets(UUID uuid, String username, String client) {
-        try {
-            Map<String, JsonTexture> map = requester.<Map<String, JsonTexture>>send(requester.get(RequestTextureProvider.getTextureURL(url, uuid, username, client), bearerToken), MAP_TYPE).getOrThrow();
-            return JsonTexture.convertMap(map);
-        } catch (IOException e) {
-            logger.error("JsonTextureProvider", e);
-            return new HashMap<>();
+        String textureUrl = RequestTextureProvider.getTextureURL(url, uuid, username, client);
+        for (int attempt = 0; attempt < 3; attempt++) {
+            try {
+                var result = requester.<Map<String, JsonTexture>>send(
+                        requester.get(textureUrl, bearerToken), MAP_TYPE);
+                if (result.isSuccessful()) {
+                    return JsonTexture.convertMap(result.result());
+                }
+                if (result.statusCode() == 429 && attempt < 2) {
+                    logger.warn("Texture API rate limited (user={}, attempt={}/3)", username, attempt + 1);
+                    Thread.sleep(1000L * (attempt + 1));
+                    continue;
+                }
+                logger.warn("Texture API request failed (user={}, status={}, error={}, url={})",
+                        username, result.statusCode(), result.error(), textureUrl);
+                return new HashMap<>();
+            } catch (IOException e) {
+                logger.error("JsonTextureProvider", e);
+                return new HashMap<>();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return new HashMap<>();
+            }
         }
+        return new HashMap<>();
     }
 
     public record JsonTexture(String url, String digest, Map<String, String> metadata) {

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/auth/texture/JsonTextureProvider.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/auth/texture/JsonTextureProvider.java
@@ -7,11 +7,14 @@ import pro.gravit.launcher.base.profiles.Texture;
 import pro.gravit.launchserver.HttpRequester;
 import pro.gravit.utils.helper.SecurityHelper;
 
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 public class JsonTextureProvider extends TextureProvider {
     private static final Type MAP_TYPE = new TypeToken<Map<String, JsonTexture>>() {
@@ -41,30 +44,36 @@ public class JsonTextureProvider extends TextureProvider {
     @Override
     public Map<String, Texture> getAssets(UUID uuid, String username, String client) {
         String textureUrl = RequestTextureProvider.getTextureURL(url, uuid, username, client);
-        for (int attempt = 0; attempt < 3; attempt++) {
-            try {
-                var result = requester.<Map<String, JsonTexture>>send(
-                        requester.get(textureUrl, bearerToken), MAP_TYPE);
-                if (result.isSuccessful()) {
-                    return JsonTexture.convertMap(result.result());
-                }
-                if (result.statusCode() == 429 && attempt < 2) {
-                    logger.warn("Texture API rate limited (user={}, attempt={}/3)", username, attempt + 1);
-                    Thread.sleep(1000L * (attempt + 1));
-                    continue;
-                }
-                logger.warn("Texture API request failed (user={}, status={}, error={}, url={})",
-                        username, result.statusCode(), result.error(), textureUrl);
-                return new HashMap<>();
-            } catch (IOException e) {
-                logger.error("JsonTextureProvider", e);
-                return new HashMap<>();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return new HashMap<>();
-            }
+        try {
+            return fetchWithRetry(textureUrl, username, 0)
+                    .orTimeout(10, TimeUnit.SECONDS)
+                    .join();
+        } catch (CompletionException e) {
+            logger.error("JsonTextureProvider", e.getCause());
+            return new HashMap<>();
+        } catch (Exception e) {
+            logger.error("JsonTextureProvider", e);
+            return new HashMap<>();
         }
-        return new HashMap<>();
+    }
+
+    private CompletableFuture<Map<String, Texture>> fetchWithRetry(String textureUrl, String username, int attempt) {
+        return requester.<Map<String, JsonTexture>>sendAsync(requester.get(textureUrl, bearerToken), MAP_TYPE)
+                .thenCompose(result -> {
+                    if (result.isSuccessful()) {
+                        return CompletableFuture.completedFuture(JsonTexture.convertMap(result.result()));
+                    }
+                    if (result.statusCode() == 429 && attempt < 2) {
+                        logger.warn("Texture API rate limited (user={}, attempt={}/3)", username, attempt + 1);
+                        Executor delayed = CompletableFuture.delayedExecutor(
+                                1000L * (attempt + 1), TimeUnit.MILLISECONDS);
+                        return CompletableFuture.supplyAsync(() -> null, delayed)
+                                .thenCompose(ignored -> fetchWithRetry(textureUrl, username, attempt + 1));
+                    }
+                    logger.warn("Texture API request failed (user={}, status={}, error={}, url={})",
+                            username, result.statusCode(), result.error(), textureUrl);
+                    return CompletableFuture.completedFuture(new HashMap<>());
+                });
     }
 
     public record JsonTexture(String url, String digest, Map<String, String> metadata) {


### PR DESCRIPTION
Фикс проблем:
- Deadlock пула соединений при авторизации - queryUser() держал соединение, а loadPermissions() внутри него брал ещё 2 новых из пула. При дефолтном пуле в 3 соединения один запрос авторизации с permissions блокировал весь пул. 
- Утечки PreparedStatement в MySQLCoreProvider - во всех 8 методах работы с HWID PreparedStatement создавался без try-with-resources и не закрывался. Все обёрнуты в try-with-resources
- Full table scan при поиске HWID - getHardwareInfoByData() загружал всю таблицу hwids без WHERE и сравнивал в рантайме. Добавлен предварительный SQL-фильтр по hwDiskId/baseboardSerialNumber с fallback на полный скан
- Texture API без retry - при 429 (rate limit) от API текстур ошибка молча проглатывалась. Добавлен async retry через CompletableFuture.delayedExecutor() - до 3 попыток с backoff, без блокировки handler-потока
- Synchronized bottleneck на getConnection() - в MySQLSourceConfig и PostgreSQLSourceConfig весь метод getConnection() был synchronized, блокируя все потоки даже после инициализации пула. Заменено на double-checked locking с volatile
- SimpleError{error='null', code=0} - при ошибках HTTP API SimpleError десериализовался с null-полями, теряя информацию о status code. Теперь при пустом/невалидном ответе создаётся SimpleError("HTTP " + statusCode)
- В getUsersByHardwareInfo замена while(!set.isLast()) на while(set.next())