### PR TITLE
[FEATURE] Add client profile token restore and enforce join/check profile binding

### DIFF
--- a/components/launcher-api/src/main/java/pro/gravit/launcher/base/events/request/SetProfileRequestEvent.java
+++ b/components/launcher-api/src/main/java/pro/gravit/launcher/base/events/request/SetProfileRequestEvent.java
@@ -1,32 +1,56 @@
 package pro.gravit.launcher.base.events.request;
 
 import pro.gravit.launcher.core.LauncherNetworkAPI;
+import pro.gravit.launcher.base.events.ExtendedTokenRequestEvent;
 import pro.gravit.launcher.base.events.RequestEvent;
 import pro.gravit.launcher.base.profiles.ClientProfile;
 
 import java.util.UUID;
 
 
-public class SetProfileRequestEvent extends RequestEvent {
+public class SetProfileRequestEvent extends RequestEvent implements ExtendedTokenRequestEvent {
+    public static final String CLIENT_PROFILE_EXTENDED_TOKEN_NAME = "clientProfile";
     @SuppressWarnings("unused")
     private static final UUID uuid = UUID.fromString("08c0de9e-4364-4152-9066-8354a3a48541");
     @LauncherNetworkAPI
     public final ClientProfile newProfile;
     @LauncherNetworkAPI
     public final String tag;
+    public final String profileExtendedToken;
+    public final long profileExtendedTokenExpire;
 
     public SetProfileRequestEvent(ClientProfile newProfile) {
-        this.newProfile = newProfile;
-        this.tag = null;
+        this(newProfile, null, null, 0);
     }
 
     public SetProfileRequestEvent(ClientProfile newProfile, String tag) {
+        this(newProfile, tag, null, 0);
+    }
+
+    public SetProfileRequestEvent(ClientProfile newProfile, String tag, String profileExtendedToken, long profileExtendedTokenExpire) {
         this.newProfile = newProfile;
         this.tag = tag;
+        this.profileExtendedToken = profileExtendedToken;
+        this.profileExtendedTokenExpire = profileExtendedTokenExpire;
     }
 
     @Override
     public String getType() {
         return "setProfile";
+    }
+
+    @Override
+    public String getExtendedTokenName() {
+        return CLIENT_PROFILE_EXTENDED_TOKEN_NAME;
+    }
+
+    @Override
+    public String getExtendedToken() {
+        return profileExtendedToken;
+    }
+
+    @Override
+    public long getExtendedTokenExpire() {
+        return profileExtendedTokenExpire;
     }
 }

--- a/components/launcher-api/src/main/java/pro/gravit/launcher/base/profiles/optional/OptionalFile.java
+++ b/components/launcher-api/src/main/java/pro/gravit/launcher/base/profiles/optional/OptionalFile.java
@@ -14,6 +14,7 @@ public class OptionalFile implements ProfileFeatureAPI.OptionalMod {
     public List<OptionalAction> actions;
     @LauncherNetworkAPI
     public boolean mark;
+    public transient boolean enabledByDefault;
     @LauncherNetworkAPI
     public boolean visible = true;
     @LauncherNetworkAPI

--- a/components/launcher-api/src/main/java/pro/gravit/launcher/base/profiles/optional/OptionalView.java
+++ b/components/launcher-api/src/main/java/pro/gravit/launcher/base/profiles/optional/OptionalView.java
@@ -18,9 +18,6 @@ public class OptionalView {
 
     public OptionalView(ClientProfile profile) {
         this.all = profile.getOptional();
-        for (OptionalFile f : this.all) {
-            if (f.mark) enable(f, true, null);
-        }
     }
 
     public OptionalView(OptionalView view) {

--- a/components/launcher-runtime/src/main/java/pro/gravit/launcher/runtime/backend/ProfileSettingsImpl.java
+++ b/components/launcher-runtime/src/main/java/pro/gravit/launcher/runtime/backend/ProfileSettingsImpl.java
@@ -26,6 +26,8 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
     @LauncherNetworkAPI
     private Set<String> enabled;
     @LauncherNetworkAPI
+    private Set<String> disabled;
+    @LauncherNetworkAPI
     private String saveJavaPath;
     transient OptionalView view;
     transient volatile JavaHelper.JavaVersion selectedJava;
@@ -184,6 +186,7 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
         cloned.ram = new HashMap<>(ram);
         cloned.flags = new HashSet<>(flags);
         cloned.enabled = new HashSet<>(enabled);
+        cloned.disabled = disabled == null ? null : new HashSet<>(disabled);
         if(view != null) {
             cloned.view = new OptionalView(profile, view);
         }
@@ -194,8 +197,14 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
 
     public void updateEnabledMods() {
         enabled = new HashSet<>();
+        disabled = new HashSet<>();
         for(var e : view.enabled) {
             enabled.add(e.name);
+        }
+        for (var e : view.all) {
+            if (e.mark && !view.isEnabled(e)) {
+                disabled.add(e.name);
+            }
         }
         if(selectedJava != null) {
             saveJavaPath = selectedJava.getPath().toAbsolutePath().toString();
@@ -207,12 +216,23 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
         this.profile = profile;
         this.view = new OptionalView(profile);
         processTriggers(profile, this.view);
-        for(var e : enabled) {
-            var opt = profile.getOptionalFile(e);
-            if(opt == null) {
-                continue;
+        if (disabled != null) {
+            for (var e : disabled) {
+                var opt = profile.getOptionalFile(e);
+                if (opt == null) {
+                    continue;
+                }
+                disableOptional(opt, (var1, var2) -> {});
             }
-            enableOptional(opt, (var1, var2) -> {});
+        }
+        if (enabled != null) {
+            for(var e : enabled) {
+                var opt = profile.getOptionalFile(e);
+                if(opt == null) {
+                    continue;
+                }
+                enableOptional(opt, (var1, var2) -> {});
+            }
         }
         if(this.saveJavaPath != null) {
             backend.getAvailableJava().thenAccept((javas) -> {

--- a/components/launcher-runtime/src/main/java/pro/gravit/launcher/runtime/backend/ProfileSettingsImpl.java
+++ b/components/launcher-runtime/src/main/java/pro/gravit/launcher/runtime/backend/ProfileSettingsImpl.java
@@ -26,8 +26,6 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
     @LauncherNetworkAPI
     private Set<String> enabled;
     @LauncherNetworkAPI
-    private Set<String> disabled;
-    @LauncherNetworkAPI
     private String saveJavaPath;
     transient OptionalView view;
     transient volatile JavaHelper.JavaVersion selectedJava;
@@ -53,6 +51,7 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
             this.flags.add(Flag.LINUX_WAYLAND_SUPPORT);
         }
         processTriggers(profile, this.view);
+        applyEnabledByDefault(this.view);
     }
 
     @Override
@@ -185,8 +184,7 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
         cloned.profile = profile;
         cloned.ram = new HashMap<>(ram);
         cloned.flags = new HashSet<>(flags);
-        cloned.enabled = new HashSet<>(enabled);
-        cloned.disabled = disabled == null ? null : new HashSet<>(disabled);
+        cloned.enabled = enabled == null ? null : new HashSet<>(enabled);
         if(view != null) {
             cloned.view = new OptionalView(profile, view);
         }
@@ -197,14 +195,8 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
 
     public void updateEnabledMods() {
         enabled = new HashSet<>();
-        disabled = new HashSet<>();
         for(var e : view.enabled) {
             enabled.add(e.name);
-        }
-        for (var e : view.all) {
-            if (e.mark && !view.isEnabled(e)) {
-                disabled.add(e.name);
-            }
         }
         if(selectedJava != null) {
             saveJavaPath = selectedJava.getPath().toAbsolutePath().toString();
@@ -216,19 +208,12 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
         this.profile = profile;
         this.view = new OptionalView(profile);
         processTriggers(profile, this.view);
-        if (disabled != null) {
-            for (var e : disabled) {
-                var opt = profile.getOptionalFile(e);
-                if (opt == null) {
-                    continue;
-                }
-                disableOptional(opt, (var1, var2) -> {});
-            }
-        }
-        if (enabled != null) {
+        if (enabled == null) {
+            applyEnabledByDefault(this.view);
+        } else {
             for(var e : enabled) {
                 var opt = profile.getOptionalFile(e);
-                if(opt == null) {
+                if (opt == null) {
                     continue;
                 }
                 enableOptional(opt, (var1, var2) -> {});
@@ -257,11 +242,12 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
     public void processTriggers(ClientProfile profile, OptionalView view) {
         TriggerManagerContext context = new TriggerManagerContext(profile);
         for (OptionalFile optional : view.all) {
+            optional.enabledByDefault = optional.mark;
             if (optional.limited) {
                 if (!backend.hasPermission("launcher.runtime.optionals.%s.%s.show"
                         .formatted(profile.getUUID(),
                                 optional.name.toLowerCase(Locale.ROOT)))) {
-                    view.disable(optional, null);
+                    optional.enabledByDefault = false;
                     optional.visible = false;
                 } else {
                     optional.visible = true;
@@ -280,10 +266,17 @@ public class ProfileSettingsImpl implements LauncherBackendAPI.ClientProfileSett
                 }
             }
             if (isRequired) {
-                if (fail == 0) view.enable(optional, true, null);
-                else view.disable(optional, null);
+                optional.enabledByDefault = fail == 0;
             } else {
-                if (success > 0) view.enable(optional, false, null);
+                if (success > 0) optional.enabledByDefault = true;
+            }
+        }
+    }
+
+    private void applyEnabledByDefault(OptionalView view) {
+        for (OptionalFile optional : view.all) {
+            if (optional.visible && optional.enabledByDefault) {
+                view.enable(optional, false, null);
             }
         }
     }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/config/LaunchServerConfig.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/config/LaunchServerConfig.java
@@ -294,5 +294,6 @@ public final class LaunchServerConfig {
         public long publicKeyTokenExpire = HOURS.toSeconds(8);
 
         public long launcherTokenExpire = HOURS.toSeconds(8);
+        public long joinServerTimeoutMillis = 10_000;
     }
 }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/config/LaunchServerConfig.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/config/LaunchServerConfig.java
@@ -294,6 +294,5 @@ public final class LaunchServerConfig {
         public long publicKeyTokenExpire = HOURS.toSeconds(8);
 
         public long launcherTokenExpire = HOURS.toSeconds(8);
-        public long joinServerTimeoutMillis = 10_000;
     }
 }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/manangers/AuthManager.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/manangers/AuthManager.java
@@ -36,7 +36,6 @@ import java.time.ZoneOffset;
 import java.util.*;
 
 public class AuthManager {
-    public static final String WRONG_CLIENT_ERROR_MESSAGE = "Wrong Client";
     private transient final LaunchServer server;
     private transient final Logger logger = LogManager.getLogger();
     private transient final JwtParser checkServerTokenParser;
@@ -217,48 +216,7 @@ public class AuthManager {
 
     public boolean joinServer(Client client, String username, UUID uuid, String accessToken, String serverID) throws IOException {
         if (client.auth == null) return false;
-        UUID profileUUID = resolveCurrentClientProfileUUID(client);
-        if(client.type == AuthResponse.ConnectTypes.CLIENT && profileUUID == null) {
-            logger.warn("joinServer denied: profile is not selected/restored for user {} (serverID={})",
-                    username != null ? username : uuid, serverID);
-            return false;
-        }
-        if(!isJoinServerProfileAllowed(client, profileUUID, serverID)) {
-            throw new AuthException(WRONG_CLIENT_ERROR_MESSAGE);
-        }
         return client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
-    }
-
-    private boolean isJoinServerProfileAllowed(Client client, UUID profileUUID, String serverID) {
-        if(client.type != AuthResponse.ConnectTypes.CLIENT || profileUUID == null || serverID == null) {
-            return true;
-        }
-        try {
-            UUID requestedProfileUUID = UUID.fromString(serverID);
-            if(profileUUID.equals(requestedProfileUUID)) {
-                return true;
-            }
-            logger.warn("joinServer denied: profile mismatch for user {} (serverID={}, selectedProfile={})",
-                    client.username != null ? client.username : client.uuid, serverID, profileUUID);
-            return false;
-        } catch (IllegalArgumentException ignored) {
-            return true;
-        }
-    }
-
-    private UUID resolveCurrentClientProfileUUID(Client client) {
-        if(client.profile != null) {
-            return client.profile.getUuid();
-        }
-        String serverName = client.getProperty("launchserver.serverName");
-        if(serverName == null) {
-            return null;
-        }
-        try {
-            return UUID.fromString(serverName);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
     }
 
     public PlayerProfile getPlayerProfile(Client client) {

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/manangers/AuthManager.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/manangers/AuthManager.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import pro.gravit.launcher.base.ClientPermissions;
 import pro.gravit.launcher.base.events.request.AuthRequestEvent;
+import pro.gravit.launcher.base.events.request.SetProfileRequestEvent;
 import pro.gravit.launcher.base.profiles.ClientProfile;
 import pro.gravit.launcher.base.profiles.PlayerProfile;
 import pro.gravit.launcher.base.request.auth.AuthRequest;
@@ -20,6 +21,7 @@ import pro.gravit.launchserver.auth.core.interfaces.provider.AuthSupportExtended
 import pro.gravit.launchserver.auth.core.interfaces.session.UserSessionSupportKeys;
 import pro.gravit.launchserver.auth.core.interfaces.user.UserSupportProperties;
 import pro.gravit.launchserver.auth.core.interfaces.user.UserSupportTextures;
+import pro.gravit.launchserver.auth.profiles.ProfilesProvider;
 import pro.gravit.launchserver.auth.texture.TextureProvider;
 import pro.gravit.launchserver.socket.Client;
 import pro.gravit.launchserver.socket.response.auth.AuthResponse;
@@ -29,18 +31,34 @@ import pro.gravit.utils.helper.SecurityHelper;
 
 import javax.crypto.Cipher;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class AuthManager {
+    public static final String WRONG_CLIENT_ERROR_MESSAGE = "Wrong Client";
+    public static final String AUTH_BACKEND_TIMEOUT_ERROR_MESSAGE = "Auth backend timeout";
     private transient final LaunchServer server;
     private transient final Logger logger = LogManager.getLogger();
     private transient final JwtParser checkServerTokenParser;
+    private transient final JwtParser clientProfileTokenParser;
+    private final transient Map<String, UUID> joinServerProfilesByServerId = new ConcurrentHashMap<>();
 
     public AuthManager(LaunchServer server) {
         this.server = server;
         this.checkServerTokenParser = Jwts.parser()
                 .requireIssuer("LaunchServer")
                 .require("tokenType", "checkServer")
+                .verifyWith(server.keyAgreementManager.ecdsaPublicKey)
+                .build();
+        this.clientProfileTokenParser = Jwts.parser()
+                .requireIssuer("LaunchServer")
+                .require("tokenType", SetProfileRequestEvent.CLIENT_PROFILE_EXTENDED_TOKEN_NAME)
                 .verifyWith(server.keyAgreementManager.ecdsaPublicKey)
                 .build();
     }
@@ -61,6 +79,34 @@ public class AuthManager {
             var jwt = checkServerTokenParser.parseClaimsJws(token).getBody();
             var isPublicClaim = jwt.get("isPublic", Boolean.class);
             return new CheckServerTokenInfo(jwt.get("serverName", String.class), jwt.get("authId", String.class), isPublicClaim == null || isPublicClaim);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public String newClientProfileToken(UUID profileUUID, String profileTag, String authId) {
+        var builder = Jwts.builder()
+                .issuer("LaunchServer")
+                .claim("tokenType", SetProfileRequestEvent.CLIENT_PROFILE_EXTENDED_TOKEN_NAME)
+                .claim("profileUUID", profileUUID.toString());
+        if (profileTag != null) {
+            builder = builder.claim("profileTag", profileTag);
+        }
+        if (authId != null) {
+            builder = builder.claim("authId", authId);
+        }
+        return builder.setExpiration(Date.from(LocalDateTime.now().plusSeconds(server.config.netty.security.launcherTokenExpire).toInstant(ZoneOffset.UTC)))
+                .signWith(server.keyAgreementManager.ecdsaPrivateKey)
+                .compact();
+    }
+
+    public ClientProfileTokenInfo parseClientProfileToken(String token) {
+        try {
+            var jwt = clientProfileTokenParser.parseClaimsJws(token).getBody();
+            return new ClientProfileTokenInfo(
+                    UUID.fromString(jwt.get("profileUUID", String.class)),
+                    jwt.get("profileTag", String.class),
+                    jwt.get("authId", String.class));
         } catch (Exception e) {
             return null;
         }
@@ -168,17 +214,108 @@ public class AuthManager {
         if(supportExtended != null) {
             var session = supportExtended.extendedCheckServer(client, username, serverID);
             if(session == null) return null;
+            if(!isCheckServerProfileAllowed(client, serverID)) {
+                throw new AuthException(WRONG_CLIENT_ERROR_MESSAGE);
+            }
             return CheckServerReport.ofUserSession(session, getPlayerProfile(client.auth, session.getUser()));
         } else {
             var user = client.auth.core.checkServer(client, username, serverID);
             if (user == null) return null;
+            if(!isCheckServerProfileAllowed(client, serverID)) {
+                throw new AuthException(WRONG_CLIENT_ERROR_MESSAGE);
+            }
             return CheckServerReport.ofUser(user, getPlayerProfile(client.auth, user));
         }
     }
 
     public boolean joinServer(Client client, String username, UUID uuid, String accessToken, String serverID) throws IOException {
         if (client.auth == null) return false;
-        return client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
+        UUID profileUUID = resolveCurrentClientProfileUUID(client);
+        if(client.type == AuthResponse.ConnectTypes.CLIENT && profileUUID == null) {
+            logger.warn("joinServer denied: profile is not selected/restored for user {} (serverID={})",
+                    username != null ? username : uuid, serverID);
+            return false;
+        }
+        long joinServerTimeoutMillis = server.config.netty.security.joinServerTimeoutMillis;
+        boolean result;
+        if (joinServerTimeoutMillis <= 0) {
+            result = client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
+        } else {
+            var joinServerFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            try {
+                result = joinServerFuture.get(joinServerTimeoutMillis, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                joinServerFuture.cancel(true);
+                logger.warn("joinServer timed out after {} ms for user {} (serverID={})",
+                        joinServerTimeoutMillis, username != null ? username : uuid, serverID);
+                throw new AuthException(AUTH_BACKEND_TIMEOUT_ERROR_MESSAGE);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("joinServer interrupted", e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException runtimeException && runtimeException.getCause() instanceof IOException ioException) {
+                    throw ioException;
+                }
+                if (cause instanceof IOException ioException) {
+                    throw ioException;
+                }
+                throw new IOException("joinServer failed", cause);
+            }
+        }
+        if(result && serverID != null && profileUUID != null) {
+            joinServerProfilesByServerId.put(serverID, profileUUID);
+        }
+        return result;
+    }
+
+    private boolean isCheckServerProfileAllowed(Client client, String serverID) {
+        if(serverID == null) {
+            return true;
+        }
+        UUID expectedProfileUUID = joinServerProfilesByServerId.remove(serverID);
+        if(expectedProfileUUID == null) {
+            UUID currentProfileUUID = resolveCurrentClientProfileUUID(client);
+            if(currentProfileUUID == null) {
+                return true;
+            }
+            logger.warn("checkServer denied: no joinServer profile context for serverID={}, but server profile is {}",
+                    serverID, currentProfileUUID);
+            return false;
+        }
+        UUID currentProfileUUID = resolveCurrentClientProfileUUID(client);
+        if(currentProfileUUID == null) {
+            logger.warn("checkServer denied: server profile is not resolved, expected profile {} for serverID={}",
+                    expectedProfileUUID, serverID);
+            return false;
+        }
+        if(!currentProfileUUID.equals(expectedProfileUUID)) {
+            logger.warn("checkServer denied: profile mismatch for serverID={} (expected={}, current={})",
+                    serverID, expectedProfileUUID, currentProfileUUID);
+            return false;
+        }
+        return true;
+    }
+
+    private UUID resolveCurrentClientProfileUUID(Client client) {
+        if(client.profile != null) {
+            return client.profile.getUuid();
+        }
+        String serverName = client.getProperty("launchserver.serverName");
+        if(serverName == null) {
+            return null;
+        }
+        try {
+            return UUID.fromString(serverName);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     public PlayerProfile getPlayerProfile(Client client) {
@@ -298,6 +435,9 @@ public class AuthManager {
     public record CheckServerTokenInfo(String serverName, String authId, boolean isPublic) {
     }
 
+    public record ClientProfileTokenInfo(UUID profileUUID, String profileTag, String authId) {
+    }
+
     public static class CheckServerVerifier implements RestoreResponse.ExtendedTokenProvider {
         private final LaunchServer server;
 
@@ -319,7 +459,41 @@ public class AuthManager {
                 client.permissions.addPerm("launchserver.checkserver.extended");
                 client.permissions.addPerm("launchserver.profile.%s.show".formatted(info.serverName));
             }
+            try {
+                UUID profileUUID = UUID.fromString(info.serverName);
+                ProfilesProvider.CompletedProfile profile = server.config.profilesProvider.get(profileUUID, null);
+                if(profile != null) {
+                    client.profile = profile;
+                }
+            } catch (IllegalArgumentException ignored) {
+                // serverName may be a custom value, profile restore from this token is optional
+            }
             client.setProperty("launchserver.serverName", info.serverName);
+            return true;
+        }
+    }
+
+    public static class ClientProfileTokenVerifier implements RestoreResponse.ExtendedTokenProvider {
+        private final LaunchServer server;
+
+        public ClientProfileTokenVerifier(LaunchServer server) {
+            this.server = server;
+        }
+
+        @Override
+        public boolean accept(Client client, AuthProviderPair pair, String extendedToken) {
+            var info = server.authManager.parseClientProfileToken(extendedToken);
+            if (info == null) {
+                return false;
+            }
+            if(info.authId() != null && pair != null && !info.authId().equals(pair.name)) {
+                return false;
+            }
+            ProfilesProvider.CompletedProfile profile = server.config.profilesProvider.get(info.profileUUID(), info.profileTag());
+            if (profile == null) {
+                return false;
+            }
+            client.profile = profile;
             return true;
         }
     }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/manangers/AuthManager.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/manangers/AuthManager.java
@@ -34,20 +34,13 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class AuthManager {
     public static final String WRONG_CLIENT_ERROR_MESSAGE = "Wrong Client";
-    public static final String AUTH_BACKEND_TIMEOUT_ERROR_MESSAGE = "Auth backend timeout";
     private transient final LaunchServer server;
     private transient final Logger logger = LogManager.getLogger();
     private transient final JwtParser checkServerTokenParser;
     private transient final JwtParser clientProfileTokenParser;
-    private final transient Map<String, UUID> joinServerProfilesByServerId = new ConcurrentHashMap<>();
 
     public AuthManager(LaunchServer server) {
         this.server = server;
@@ -214,16 +207,10 @@ public class AuthManager {
         if(supportExtended != null) {
             var session = supportExtended.extendedCheckServer(client, username, serverID);
             if(session == null) return null;
-            if(!isCheckServerProfileAllowed(client, serverID)) {
-                throw new AuthException(WRONG_CLIENT_ERROR_MESSAGE);
-            }
             return CheckServerReport.ofUserSession(session, getPlayerProfile(client.auth, session.getUser()));
         } else {
             var user = client.auth.core.checkServer(client, username, serverID);
             if (user == null) return null;
-            if(!isCheckServerProfileAllowed(client, serverID)) {
-                throw new AuthException(WRONG_CLIENT_ERROR_MESSAGE);
-            }
             return CheckServerReport.ofUser(user, getPlayerProfile(client.auth, user));
         }
     }
@@ -236,71 +223,27 @@ public class AuthManager {
                     username != null ? username : uuid, serverID);
             return false;
         }
-        long joinServerTimeoutMillis = server.config.netty.security.joinServerTimeoutMillis;
-        boolean result;
-        if (joinServerTimeoutMillis <= 0) {
-            result = client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
-        } else {
-            var joinServerFuture = CompletableFuture.supplyAsync(() -> {
-                try {
-                    return client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            try {
-                result = joinServerFuture.get(joinServerTimeoutMillis, TimeUnit.MILLISECONDS);
-            } catch (TimeoutException e) {
-                joinServerFuture.cancel(true);
-                logger.warn("joinServer timed out after {} ms for user {} (serverID={})",
-                        joinServerTimeoutMillis, username != null ? username : uuid, serverID);
-                throw new AuthException(AUTH_BACKEND_TIMEOUT_ERROR_MESSAGE);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IOException("joinServer interrupted", e);
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException runtimeException && runtimeException.getCause() instanceof IOException ioException) {
-                    throw ioException;
-                }
-                if (cause instanceof IOException ioException) {
-                    throw ioException;
-                }
-                throw new IOException("joinServer failed", cause);
-            }
+        if(!isJoinServerProfileAllowed(client, profileUUID, serverID)) {
+            throw new AuthException(WRONG_CLIENT_ERROR_MESSAGE);
         }
-        if(result && serverID != null && profileUUID != null) {
-            joinServerProfilesByServerId.put(serverID, profileUUID);
-        }
-        return result;
+        return client.auth.core.joinServer(client, username, uuid, accessToken, serverID);
     }
 
-    private boolean isCheckServerProfileAllowed(Client client, String serverID) {
-        if(serverID == null) {
+    private boolean isJoinServerProfileAllowed(Client client, UUID profileUUID, String serverID) {
+        if(client.type != AuthResponse.ConnectTypes.CLIENT || profileUUID == null || serverID == null) {
             return true;
         }
-        UUID expectedProfileUUID = joinServerProfilesByServerId.remove(serverID);
-        if(expectedProfileUUID == null) {
-            UUID currentProfileUUID = resolveCurrentClientProfileUUID(client);
-            if(currentProfileUUID == null) {
+        try {
+            UUID requestedProfileUUID = UUID.fromString(serverID);
+            if(profileUUID.equals(requestedProfileUUID)) {
                 return true;
             }
-            logger.warn("checkServer denied: no joinServer profile context for serverID={}, but server profile is {}",
-                    serverID, currentProfileUUID);
+            logger.warn("joinServer denied: profile mismatch for user {} (serverID={}, selectedProfile={})",
+                    client.username != null ? client.username : client.uuid, serverID, profileUUID);
             return false;
+        } catch (IllegalArgumentException ignored) {
+            return true;
         }
-        UUID currentProfileUUID = resolveCurrentClientProfileUUID(client);
-        if(currentProfileUUID == null) {
-            logger.warn("checkServer denied: server profile is not resolved, expected profile {} for serverID={}",
-                    expectedProfileUUID, serverID);
-            return false;
-        }
-        if(!currentProfileUUID.equals(expectedProfileUUID)) {
-            logger.warn("checkServer denied: profile mismatch for serverID={} (expected={}, current={})",
-                    serverID, expectedProfileUUID, currentProfileUUID);
-            return false;
-        }
-        return true;
     }
 
     private UUID resolveCurrentClientProfileUUID(Client client) {

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/socket/response/auth/RestoreResponse.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/socket/response/auth/RestoreResponse.java
@@ -4,6 +4,7 @@ import io.netty.channel.ChannelHandlerContext;
 import pro.gravit.launcher.base.events.request.AuthRequestEvent;
 import pro.gravit.launcher.base.events.request.LauncherRequestEvent;
 import pro.gravit.launcher.base.events.request.RestoreRequestEvent;
+import pro.gravit.launcher.base.events.request.SetProfileRequestEvent;
 import pro.gravit.launchserver.LaunchServer;
 import pro.gravit.launchserver.auth.AuthProviderPair;
 import pro.gravit.launchserver.auth.core.AuthCoreProvider;
@@ -34,6 +35,7 @@ public class RestoreResponse extends SimpleResponse {
             providers.put("publicKey", new AdvancedProtectHandler.PublicKeyTokenVerifier(server));
             providers.put("hardware", new AdvancedProtectHandler.HardwareInfoTokenVerifier(server));
             providers.put("checkServer", new AuthManager.CheckServerVerifier(server));
+            providers.put(SetProfileRequestEvent.CLIENT_PROFILE_EXTENDED_TOKEN_NAME, new AuthManager.ClientProfileTokenVerifier(server));
             registeredProviders = true;
         }
     }

--- a/components/launchserver/src/main/java/pro/gravit/launchserver/socket/response/auth/SetProfileResponse.java
+++ b/components/launchserver/src/main/java/pro/gravit/launchserver/socket/response/auth/SetProfileResponse.java
@@ -30,7 +30,9 @@ public class SetProfileResponse extends SimpleResponse {
             return;
         }
         client.profile = profile;
-        sendResult(new SetProfileRequestEvent(profile.getProfile(), profile.getTag()));
+        sendResult(new SetProfileRequestEvent(profile.getProfile(), profile.getTag(),
+                server.authManager.newClientProfileToken(profile.getUuid(), profile.getTag(), client.auth_id),
+                server.config.netty.security.launcherTokenExpire * 1000));
     }
 
     @Override


### PR DESCRIPTION
**SetProfile** now issues a **clientProfile** extended token, and **Restore** can recover the selected client profile from this token.
The **joinServer/checkServer** flow now validates profile consistency to prevent profile mismatch between client session state and server checks.

To send custom messages, you need to edit the authlib library to pass a convenient "Bad Client" value to the client. Otherwise, you'll get the standard error message "Authentication servers are down. Please try again later, sorry!"